### PR TITLE
fix(scripts): make it a little more portable

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 Mock for AWS API
 
 # Installation
+- It developed and tested on Debian-like OSes only
 - Make sure you have Python 3.10
 - install the Python requirements from `requirements.txt`
 
@@ -42,8 +43,7 @@ If you want to make SCT work with the same CA, you need to run this script in SC
 
     $ docker run -it --rm -p 443:443 aws_mock
 
-
-# Running aws_mock server with mapped source files:
+## Run aws_mock server with mapped source files using `run.sh` script:
 
     $ ./run.sh
 

--- a/run.sh
+++ b/run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-ROOT=$(dirname $(readlink -f "$0"))
+ROOT=$(cd "$(dirname "$0")"; pwd -P)
 
 set -xe
 

--- a/scripts/patch_etc_hosts.sh
+++ b/scripts/patch_etc_hosts.sh
@@ -13,7 +13,7 @@ fi
 AWS_MOCK_IP=${1:-127.0.0.1}
 
 echo ">>> Add hosts to /etc/hosts:"
-cat <<EOF | tee --append /etc/hosts
+cat <<EOF | tee -a /etc/hosts
 ### ADDED BY AWS MOCK TOOL ###
 ${AWS_MOCK_IP}  ec2.eu-north-1.amazonaws.com
 ${AWS_MOCK_IP}  ec2.eu-west-2.amazonaws.com


### PR DESCRIPTION
- Don't use 'readlink' command
- Use 'tee -a' instead of 'tee --append'
- Update README.md