### PR TITLE
Add support for responding ModifyVpcAttribute api call

### DIFF
--- a/aws_mock/main.py
+++ b/aws_mock/main.py
@@ -11,6 +11,7 @@ from aws_mock.requests.create_security_group import create_security_group
 from aws_mock.requests.create_subnet import create_subnet
 from aws_mock.requests.create_tags import create_tags
 from aws_mock.requests.create_vpc import create_vpc
+from aws_mock.requests.modify_vpc_attribute import modify_vpc_attribute
 from aws_mock.requests.describe_availability_zones import describe_availability_zones
 from aws_mock.requests.describe_images import describe_images
 from aws_mock.requests.describe_instances import describe_instances
@@ -91,6 +92,8 @@ def index():  # pylint: disable=too-many-return-statements
             return describe_subnets(subnet_name=request.form["Filter.1.Value.1"])
         case "ModifySubnetAttribute":
             return modify_subnet_attribute()
+        case "ModifyVpcAttribute":
+            return modify_vpc_attribute()
         case "CreateVpc":
             return create_vpc(
                 cidr_block=request.form["CidrBlock"],

--- a/aws_mock/requests/modify_vpc_attribute.py
+++ b/aws_mock/requests/modify_vpc_attribute.py
@@ -1,0 +1,6 @@
+from aws_mock.lib import aws_response
+
+
+@aws_response
+def modify_vpc_attribute() -> None:
+    pass

--- a/aws_mock/templates/responses/modify_vpc_attribute.xml
+++ b/aws_mock/templates/responses/modify_vpc_attribute.xml
@@ -1,0 +1,1 @@
+{% extends "response_true.xml" %}

--- a/tests/test_vpcs.py
+++ b/tests/test_vpcs.py
@@ -38,3 +38,20 @@ def test_describe_vpcs(run_query: RunQueryFunc, mongo: Mock) -> None:
     })
     assert b"cidrBlock" in response.data
     assert f"<vpcId>{VPC_ID}</vpcId>".encode("ascii") in response.data
+
+
+def test_modify_vpc_attribute(run_query: RunQueryFunc, mongo: Mock) -> None:
+    mongo().aws_mock["vpc"].find.return_value = [{
+        "_id": "MOCKED_ID",
+        "id": VPC_ID,
+        "tags": {},
+    }]
+    response = run_query({
+        "Action": "ModifyVpcAttribute",
+        "Version": "2016-11-15",
+        "MapPublicIpOnLaunch.Value": "true",
+        "VpcId": VPC_ID,
+    })
+    assert b"ModifyVpcAttributeResponse" in response.data
+    assert b"<return>true</return>" in response.data
+    mongo().aws_mock["vpc"].find.assert_not_called()


### PR DESCRIPTION
In a PR in SCT, we start using:

```python
vpc.modify_attribute(EnableDnsHostnames={"Value": True})
```

so the mock need to support this api call

Ref: https://github.com/scylladb/scylla-cluster-tests/pull/4855